### PR TITLE
Feature/use u128 for epoch and block number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,6 +2642,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.133",
  "serde_json 1.0.75",
+ "thiserror",
  "tokio",
  "tracing",
  "url 0.2.38",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ paris = { version = "1.5.8", features = ["timestamps", "macros"] }
 reqwest = { version = "0.11.9", features = ["blocking", "json", "stream"], optional = true }
 serde = "1.0.132"
 serde_json = "1.0.73"
+thiserror = "1.0"
 tokio = { version = "1.15.0", features = ["full"] }
 tracing = "0.1.29"
 url = { version = "0.2.2", optional = true }

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -38,15 +38,15 @@
 CREATE TABLE IF NOT EXISTS bundle (
     id CHAR(43) NOT NULL,
     owner_address CHAR(43) NOT NULL,
-    block_height BIGINT NOT NULL,
+    block_height BINARY(16) NOT NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS transactions (
     id CHAR(43) NOT NULL,
     epoch BINARY(16) NOT NULL,
-    block_promised BIGINT NOT NULL,
-    block_actual BIGINT,
+    block_promised BINARY(16) NOT NULL,
+    block_actual BINARY(16),
     signature BLOB NOT NULL,
     validated BOOLEAN NOT NULL,
     bundle_id CHAR(43),

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS bundle (
 
 CREATE TABLE IF NOT EXISTS transactions (
     id CHAR(43) NOT NULL,
-    epoch BIGINT NOT NULL,
+    epoch BINARY(16) NOT NULL,
     block_promised BIGINT NOT NULL,
     block_actual BIGINT,
     signature BLOB NOT NULL,

--- a/src/context.rs
+++ b/src/context.rs
@@ -61,7 +61,7 @@ impl<HttpClient> queries::QueryContext for AppContext<HttpClient> {
             .expect("Failed to get connection from database connection pool")
     }
 
-    fn current_epoch(&self) -> i64 {
+    fn current_epoch(&self) -> u128 {
         0
     }
 }
@@ -87,7 +87,7 @@ impl<HttpClient> server::routes::sign::Config<Arc<InMemoryKeyManager>> for AppCo
         self.key_manager.validator_address()
     }
 
-    fn current_epoch(&self) -> i64 {
+    fn current_epoch(&self) -> u128 {
         0
     }
 

--- a/src/cron/bundle.rs
+++ b/src/cron/bundle.rs
@@ -5,7 +5,7 @@ use super::error::ValidatorCronError;
 use super::slasher::vote_slash;
 use super::transactions::get_transactions;
 use crate::cron::arweave::{Arweave, Transaction as ArweaveTx};
-use crate::database::models::{NewBundle, NewTransaction};
+use crate::database::models::{Epoch, NewBundle, NewTransaction};
 use crate::database::queries::{self, *};
 use crate::http;
 use crate::types::Validator;
@@ -232,7 +232,7 @@ where
                     ctx,
                     &NewTransaction {
                         id: receipt.tx_id,
-                        epoch: 0, // TODO: implement epoch correctly
+                        epoch: Epoch(0),
                         block_promised: receipt.block.try_into().unwrap(), // FIXME: don't use unwrap
                         block_actual: current_block,
                         signature: receipt.signature.as_bytes().to_vec(),

--- a/src/cron/bundle.rs
+++ b/src/cron/bundle.rs
@@ -5,7 +5,7 @@ use super::error::ValidatorCronError;
 use super::slasher::vote_slash;
 use super::transactions::get_transactions;
 use crate::cron::arweave::{Arweave, Transaction as ArweaveTx};
-use crate::database::models::{Epoch, NewBundle, NewTransaction};
+use crate::database::models::{Block, Epoch, NewBundle, NewTransaction};
 use crate::database::queries::{self, *};
 use crate::http;
 use crate::types::Validator;
@@ -17,7 +17,6 @@ use bundlr_sdk::{deep_hash::DeepHashChunk, verify::file::verify_file_bundle};
 use data_encoding::BASE64URL_NOPAD;
 use jsonwebkey::JsonWebKey;
 use lazy_static::lazy_static;
-use num_traits::ToPrimitive;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Public};
 use openssl::rsa::Padding;
@@ -103,7 +102,7 @@ where
     HttpClient: http::Client<Request = reqwest::Request, Response = reqwest::Response>,
 {
     let block_ok = check_bundle_block(ctx, bundler, bundle).await;
-    let current_block: Option<i64> = None;
+    let current_block: Option<u128> = None;
     if let Err(err) = block_ok {
         return Err(err);
     }
@@ -152,15 +151,12 @@ async fn check_bundle_block<Context>(
     ctx: &Context,
     bundler: &Bundler,
     bundle: &ArweaveTx,
-) -> Result<Option<i64>, ValidatorCronError>
+) -> Result<Option<u128>, ValidatorCronError>
 where
     Context: queries::QueryContext,
 {
     let current_block = match bundle.block {
-        Some(ref block) => block
-            .height
-            .to_i64()
-            .expect("Could not convert block number from u128 to i64"),
+        Some(ref block) => block.height,
         None => {
             info!(
                 "Bundle {} not included in any block, moving on ...",
@@ -179,7 +175,7 @@ where
             NewBundle {
                 id: bundle.id.clone(),
                 owner_address: bundler.address.clone(),
-                block_height: current_block,
+                block_height: Block(current_block),
             },
         ) {
             Ok(()) => {
@@ -199,7 +195,7 @@ where
 async fn verify_bundle_tx<Context>(
     ctx: &Context,
     bundle_tx: &Item,
-    current_block: Option<i64>,
+    current_block: Option<u128>,
 ) -> Result<(), ValidatorCronError>
 where
     Context: queries::QueryContext,
@@ -209,7 +205,7 @@ where
     if tx.is_ok() {
         let tx = tx.unwrap();
         tx_receipt = Some(TxReceipt {
-            block: tx.block_promised.try_into().unwrap(), // FIXME: don't use unwrap
+            block: tx.block_promised.into(),
             tx_id: tx.id,
             signature: match std::str::from_utf8(&tx.signature.to_vec()) {
                 Ok(v) => v.to_string(),
@@ -227,14 +223,14 @@ where
         Some(receipt) => {
             let tx_is_ok = verify_tx_receipt(&receipt).unwrap();
             // FIXME: don't use unwrap
-            if tx_is_ok && receipt.block <= current_block.unwrap().try_into().unwrap() {
+            if tx_is_ok && receipt.block <= current_block.unwrap() {
                 if let Err(_err) = insert_tx_in_db(
                     ctx,
                     &NewTransaction {
                         id: receipt.tx_id,
                         epoch: Epoch(0),
-                        block_promised: receipt.block.try_into().unwrap(), // FIXME: don't use unwrap
-                        block_actual: current_block,
+                        block_promised: receipt.block.into(),
+                        block_actual: current_block.map(Block),
                         signature: receipt.signature.as_bytes().to_vec(),
                         validated: true,
                         bundle_id: Some(bundle_tx.tx_id.clone()),

--- a/src/database/models.rs
+++ b/src/database/models.rs
@@ -1,7 +1,60 @@
 use super::schema::bundle;
 use super::schema::transactions;
+use diesel::sql_types::Binary;
+use diesel::sqlite::Sqlite;
+use diesel::types::FromSql;
+use diesel::types::IsNull;
+use diesel::types::ToSql;
 use diesel::{Insertable, Queryable};
 use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DeserializationError {
+    #[error("unexpected null value")]
+    UnexpectedNull,
+    #[error("invalid byte lenght, expecting {0} bytes, received {1}")]
+    InvalidByteLength(usize, usize),
+}
+
+#[derive(Clone, Copy, Debug, Serialize, FromSqlRow, AsExpression, PartialEq)]
+#[diesel(foreigh_type)]
+#[sql_type = "Binary"]
+pub struct Epoch(pub u128);
+
+impl TryFrom<&[u8]> for Epoch {
+    type Error = DeserializationError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() == 16 {
+            let mut b: [u8; 16] = [0; 16];
+            b.copy_from_slice(bytes);
+            Ok(Self(u128::from_ne_bytes(b)))
+        } else {
+            Err(DeserializationError::InvalidByteLength(16, bytes.len()))
+        }
+    }
+}
+
+impl FromSql<Binary, Sqlite> for Epoch {
+    fn from_sql(
+        bytes: Option<&<Sqlite as diesel::backend::Backend>::RawValue>,
+    ) -> diesel::deserialize::Result<Self> {
+        let bytes = bytes.ok_or_else(|| Box::new(DeserializationError::UnexpectedNull))?;
+        let bytes = bytes.read_blob();
+        Epoch::try_from(bytes).map_err(|err| Box::new(err).into())
+    }
+}
+
+impl ToSql<Binary, Sqlite> for Epoch {
+    fn to_sql<W: std::io::Write>(
+        &self,
+        out: &mut diesel::serialize::Output<W, Sqlite>,
+    ) -> diesel::serialize::Result {
+        let bytes: [u8; 16] = self.0.to_ne_bytes();
+        out.write(&bytes).map(|_| IsNull::No).map_err(Into::into)
+    }
+}
 
 #[derive(Serialize, Queryable)]
 pub struct Bundle {
@@ -18,10 +71,10 @@ pub struct NewBundle {
     pub block_height: i64,
 }
 
-#[derive(Serialize, Queryable)]
+#[derive(Debug, PartialEq, Serialize, Queryable)]
 pub struct Transaction {
     pub id: String,
-    pub epoch: i64,
+    pub epoch: Epoch,
     pub block_promised: i64,
     pub block_actual: Option<i64>,
     pub signature: Vec<u8>,
@@ -33,10 +86,57 @@ pub struct Transaction {
 #[table_name = "transactions"]
 pub struct NewTransaction {
     pub id: String,
-    pub epoch: i64,
+    pub epoch: Epoch,
     pub block_promised: i64,
     pub block_actual: Option<i64>,
     pub signature: Vec<u8>,
     pub validated: bool,
     pub bundle_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel::{Connection, RunQueryDsl, SqliteConnection};
+
+    use crate::database::schema::transactions::dsl;
+
+    use super::{Epoch, NewTransaction, Transaction};
+
+    embed_migrations!();
+
+    #[test]
+    fn insert_and_read_transaction() {
+        let conn = SqliteConnection::establish(":memory:").unwrap();
+        embedded_migrations::run(&conn).unwrap();
+
+        let tx = NewTransaction {
+            id: "foo".to_string(),
+            epoch: Epoch(340282366920938463463374607431768211455),
+            block_promised: 1,
+            block_actual: None,
+            signature: "foo".as_bytes().to_vec(),
+            validated: false,
+            bundle_id: None,
+        };
+
+        diesel::insert_into(dsl::transactions)
+            .values(&tx)
+            .execute(&conn)
+            .unwrap();
+
+        let result = dsl::transactions.load::<Transaction>(&conn).unwrap();
+
+        assert_eq!(
+            result[0],
+            Transaction {
+                id: "foo".to_string(),
+                epoch: Epoch(340282366920938463463374607431768211455),
+                block_promised: 1,
+                block_actual: None,
+                signature: "foo".as_bytes().to_vec(),
+                validated: false,
+                bundle_id: None,
+            }
+        )
+    }
 }

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -11,7 +11,7 @@ use crate::state::ValidatorStateAccess;
 
 pub trait QueryContext: ValidatorStateAccess {
     fn get_db_connection(&self) -> PooledConnection<ConnectionManager<SqliteConnection>>;
-    fn current_epoch(&self) -> i64;
+    fn current_epoch(&self) -> u128;
 }
 
 pub fn get_bundle<Context>(ctx: &Context, b_id: &str) -> Result<Bundle, Error>

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -15,7 +15,7 @@ table! {
 table! {
     transactions (id) {
         id -> Text,
-        epoch -> BigInt,
+        epoch -> Binary,
         block_promised -> BigInt,
         block_actual -> Nullable<BigInt>,
         signature -> Binary,

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -2,7 +2,7 @@ table! {
     bundle (id) {
         id -> Text,
         owner_address -> Text,
-        block_height -> BigInt,
+        block_height -> Binary,
     }
 }
 
@@ -16,8 +16,8 @@ table! {
     transactions (id) {
         id -> Text,
         epoch -> Binary,
-        block_promised -> BigInt,
-        block_actual -> Nullable<BigInt>,
+        block_promised -> Binary,
+        block_actual -> Nullable<Binary>,
         signature -> Binary,
         validated -> Bool,
         bundle_id -> Nullable<Text>,

--- a/src/server/routes/sign.rs
+++ b/src/server/routes/sign.rs
@@ -24,7 +24,7 @@ where
     fn bundler_address(&self) -> &str;
     fn validator_address(&self) -> &str;
     fn key_manager(&self) -> &KeyManager;
-    fn current_epoch(&self) -> i64;
+    fn current_epoch(&self) -> u128;
     fn current_block(&self) -> u128;
 }
 
@@ -183,7 +183,7 @@ where
 
     let new_transaction = NewTransaction {
         id: body.id,
-        epoch: current_epoch,
+        epoch: current_epoch.try_into().unwrap(), // FIXME: don't unwrap
         block_promised: i64::try_from(body.block).unwrap(), // FIXME: don't unwrap
         block_actual: None,
         signature: sig.as_bytes().to_vec(),

--- a/src/server/routes/sign.rs
+++ b/src/server/routes/sign.rs
@@ -11,7 +11,10 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     consts::{BUNDLR_AS_BUFFER, VALIDATOR_AS_BUFFER},
-    database::{models::NewTransaction, schema::transactions::dsl::*},
+    database::{
+        models::{Epoch, NewTransaction},
+        schema::transactions::dsl::*,
+    },
     key_manager,
     server::{error::ValidatorServerError, RuntimeContext},
     state::{ValidatorRole, ValidatorStateAccess},
@@ -183,7 +186,7 @@ where
 
     let new_transaction = NewTransaction {
         id: body.id,
-        epoch: current_epoch.try_into().unwrap(), // FIXME: don't unwrap
+        epoch: Epoch(current_epoch),
         block_promised: i64::try_from(body.block).unwrap(), // FIXME: don't unwrap
         block_actual: None,
         signature: sig.as_bytes().to_vec(),

--- a/src/server/routes/sign.rs
+++ b/src/server/routes/sign.rs
@@ -187,7 +187,7 @@ where
     let new_transaction = NewTransaction {
         id: body.id,
         epoch: Epoch(current_epoch),
-        block_promised: i64::try_from(body.block).unwrap(), // FIXME: don't unwrap
+        block_promised: body.block.into(),
         block_actual: None,
         signature: sig.as_bytes().to_vec(),
         validated: false,


### PR DESCRIPTION
Store epoch and block number values as `Binary(16)` in the database and map this as `u128` in the model side.