### PR TITLE
Wire through current epoch and block in context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -62,7 +62,7 @@ impl<HttpClient> queries::QueryContext for AppContext<HttpClient> {
     }
 
     fn current_epoch(&self) -> u128 {
-        0
+        self.validator_state.current_epoch()
     }
 }
 
@@ -88,11 +88,11 @@ impl<HttpClient> server::routes::sign::Config<Arc<InMemoryKeyManager>> for AppCo
     }
 
     fn current_epoch(&self) -> u128 {
-        0
+        self.validator_state.current_epoch()
     }
 
     fn current_block(&self) -> u128 {
-        0
+        self.validator_state.current_block()
     }
 
     fn key_manager(&self) -> &Arc<InMemoryKeyManager> {


### PR DESCRIPTION
This wires through current epoch and block number so that those are read from the validator state when using context.