### PR TITLE
Move bundler node's connection details into context

### DIFF
--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -10,6 +10,7 @@ use diesel_migrations::embed_migrations;
 use env_logger::Env;
 use jsonwebkey::{JsonWebKey, Key, PublicExponent, RsaPublic};
 use std::{fs, net::SocketAddr};
+use url::Url;
 
 use validator::key_manager::{InMemoryKeyManager, InMemoryKeyManagerConfig};
 use validator::{context::AppContext, state::generate_state};
@@ -52,6 +53,10 @@ struct AppConfig {
         required_unless_present = "bundler-public"
     )]
     bundler_key: Option<String>,
+
+    /// URL for the bundler connection
+    #[clap(long, env = "BUNDLER_URL")]
+    bundler_url: Url,
 
     /// Path to JWK file holding validator private key
     #[clap(long, env = "VALIDATOR_KEY")]
@@ -109,6 +114,7 @@ impl From<&AppConfig> for AppContext {
             config.listen,
             state,
             reqwest::Client::new(),
+            &config.bundler_url,
         )
     }
 }

--- a/src/cron/validate.rs
+++ b/src/cron/validate.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::database::queries;
 use crate::state::ValidatorRole;
 use crate::{context, http};
@@ -8,7 +6,7 @@ use super::arweave;
 use super::bundle::validate_bundler;
 use super::error::ValidatorCronError;
 
-pub async fn validate<Context, HttpClient>(ctx: Arc<Context>) -> Result<(), ValidatorCronError>
+pub async fn validate<Context, HttpClient>(ctx: &Context) -> Result<(), ValidatorCronError>
 where
     Context: queries::QueryContext + arweave::ArweaveContext<HttpClient> + context::BundlerAccess,
     HttpClient: http::Client<Request = reqwest::Request, Response = reqwest::Response>,
@@ -21,7 +19,7 @@ where
     Ok(())
 }
 
-pub async fn validate_transactions<Context>(ctx: Arc<Context>) -> Result<(), ValidatorCronError>
+pub async fn validate_transactions<Context>(ctx: &Context) -> Result<(), ValidatorCronError>
 where
     Context: context::BundlerAccess,
 {

--- a/src/cron/validate.rs
+++ b/src/cron/validate.rs
@@ -1,31 +1,31 @@
-use crate::database::queries;
-use crate::http;
-use crate::state::ValidatorRole;
 use std::sync::Arc;
 
+use crate::database::queries;
+use crate::state::ValidatorRole;
+use crate::{context, http};
+
 use super::arweave;
-use super::bundle::{get_bundler, validate_bundler};
+use super::bundle::validate_bundler;
 use super::error::ValidatorCronError;
 
 pub async fn validate<Context, HttpClient>(ctx: Arc<Context>) -> Result<(), ValidatorCronError>
 where
-    Context: queries::QueryContext + arweave::ArweaveContext<HttpClient>,
+    Context: queries::QueryContext + arweave::ArweaveContext<HttpClient> + context::BundlerAccess,
     HttpClient: http::Client<Request = reqwest::Request, Response = reqwest::Response>,
 {
-    let bundler = get_bundler().await?;
-
     match ctx.get_validator_state().role() {
-        ValidatorRole::Cosigner => validate_bundler(&*ctx, bundler).await?,
+        ValidatorRole::Cosigner => validate_bundler(&*ctx).await?,
         ValidatorRole::Idle => (),
     }
 
     Ok(())
 }
 
-pub async fn validate_transactions<Context>(_: Arc<Context>) -> Result<(), ValidatorCronError> {
-    let bundler = get_bundler().await?;
-
-    super::bundle::validate_transactions(bundler).await?;
+pub async fn validate_transactions<Context>(ctx: Arc<Context>) -> Result<(), ValidatorCronError>
+where
+    Context: context::BundlerAccess,
+{
+    super::bundle::validate_transactions(ctx.bundler()).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Initialize object holding bundler address and URL in the app startup
and make these details available through Bundler object that is owned
by the context.

Also add missing command line argument for defining the URL for
connecting the bundler node.