### PR TITLE
Fix how JWK for bundler is build from the private key

### DIFF
--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -2,6 +2,7 @@
 extern crate diesel_migrations;
 
 use clap::Parser;
+use data_encoding::BASE64URL_NOPAD;
 use diesel::{
     r2d2::{self, ConnectionManager},
     sqlite::SqliteConnection,
@@ -109,7 +110,10 @@ impl From<&CliOpts> for AppContext {
             JsonWebKey::new(Key::RSA {
                 public: RsaPublic {
                     e: PublicExponent,
-                    n: n.as_bytes().into(),
+                    n: BASE64URL_NOPAD
+                        .decode(n.as_bytes().into())
+                        .expect("Failed to decode bundler's public key")
+                        .into(),
                 },
                 private: None,
             })


### PR DESCRIPTION
The private key is received as Base64URL without padding. When building
the JWK, we need to first decode the input string properly.