### PR TITLE
Put SQLite connection pool behind Arc

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -45,7 +45,7 @@ impl InMemoryKeyManagerConfig for Keys {
 #[derive(Clone)]
 pub struct AppContext<HttpClient = ReqwestClient> {
     key_manager: Arc<InMemoryKeyManager>,
-    db_conn_pool: r2d2::Pool<ConnectionManager<SqliteConnection>>,
+    db_conn_pool: Arc<r2d2::Pool<ConnectionManager<SqliteConnection>>>,
     listen: SocketAddr,
     validator_state: SharedValidatorState,
     http_client: HttpClient,
@@ -80,7 +80,7 @@ impl AppContext {
 
         Self {
             key_manager: Arc::new(key_manager),
-            db_conn_pool,
+            db_conn_pool: Arc::new(db_conn_pool),
             listen,
             validator_state,
             http_client: ReqwestClient::new(http_client),
@@ -242,7 +242,7 @@ pub mod test_utils {
 
         AppContext {
             key_manager: Arc::new(key_manager),
-            db_conn_pool,
+            db_conn_pool: Arc::new(db_conn_pool),
             listen: "127.0.0.1:10000".parse().unwrap(),
             validator_state: state,
             http_client: MockHttpClient::new(|_, _| false),
@@ -283,7 +283,7 @@ pub mod test_utils {
 
         AppContext {
             key_manager: Arc::new(key_manager),
-            db_conn_pool,
+            db_conn_pool: Arc::new(db_conn_pool),
             listen: "127.0.0.1:10000".parse().unwrap(),
             validator_state: state,
             http_client,


### PR DESCRIPTION
Cloning connection pool causes database queries to fail when running
from different threads, because it seems that this actually causes the
database to be opened multiple times instead of accessing the single
connection through the pool.

This change puts the connection behind `Arc` so that cloning the pool
actually just clones the reference to the single pool instance.