### PR TITLE
Fix/improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,12 +1887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
-name = "paris"
-version = "1.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaf2319cd71dd9ff38c72bebde61b9ea657134abcf26ae4205f54f772a32810"
-
-[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,8 +3111,8 @@ dependencies = [
  "futures-util",
  "http",
  "jsonwebkey",
+ "log",
  "openssl",
- "paris",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ futures = "0.3.19"
 futures-util = "0.3"
 http = { version = "0.2.6", optional = true }
 jsonwebkey = "0.3.4"
+log = "0.4.17"
 openssl = "0.10.40"
-paris = { version = "1.5.8", features = ["timestamps", "macros"] }
 reqwest = { version = "0.11.11", features = ["blocking", "json", "stream"], optional = true }
 serde = "1.0.132"
 serde_json = "1.0.73"

--- a/src/bin/message_builder.rs
+++ b/src/bin/message_builder.rs
@@ -42,8 +42,8 @@ fn main() {
     let args = Args::parse();
 
     let (private_key, _, _) = {
-        let wallet = fs::read_to_string(&args.wallet).unwrap();
-        let jwk: JsonWebKey = wallet.parse().unwrap();
+        let wallet = fs::read_to_string(&args.wallet).expect("Failed to find wallet file");
+        let jwk: JsonWebKey = wallet.parse().expect("Failed to parse wallet file");
         key_manager::split_jwk(&jwk)
     };
 

--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -67,7 +67,7 @@ fn merge_configs(config: CliOpts, bundler_config: BundlerConfig) -> CliOpts {
         Some(u) => Some(u),
         None => {
             let url_string = format!("https://{}", bundler_config.gateway);
-            let url = url::Url::from_str(&url_string).unwrap();
+            let url = url::Url::from_str(&url_string).expect("Invalid Arweave gateway URL");
             Some(url)
         }
     };

--- a/src/bin/wallet_tool.rs
+++ b/src/bin/wallet_tool.rs
@@ -29,7 +29,8 @@ fn main() {
 
     match args.command {
         Command::Create => {
-            let rsa = Rsa::generate(2048).unwrap();
+            let rsa = Rsa::generate(2048)
+                .expect("Failed to generate enough random data for the private key");
 
             let jwk = JsonWebKey::new(Key::RSA {
                 public: RsaPublic {
@@ -50,8 +51,8 @@ fn main() {
         }
         Command::ShowAddress { ref wallet } => {
             let (_, _, address) = {
-                let wallet = fs::read_to_string(wallet).unwrap();
-                let jwk: JsonWebKey = wallet.parse().unwrap();
+                let wallet = fs::read_to_string(wallet).expect("Failed to find wallet file");
+                let jwk: JsonWebKey = wallet.parse().expect("Failed to parse wallet file");
                 key_manager::split_jwk(&jwk)
             };
 

--- a/src/contract_gateway.rs
+++ b/src/contract_gateway.rs
@@ -3,7 +3,7 @@ use bundlr_contracts_validators::{
     slashing::Proposal as SlashProposal, slashing::Vote, State as ContractState,
 };
 use derive_more::{Display, Error};
-use paris::error;
+use log::error;
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/src/cron/arweave.rs
+++ b/src/cron/arweave.rs
@@ -1,7 +1,6 @@
-use paris::error;
-use paris::info;
-use serde::Deserialize;
-use serde::Serialize;
+use log::error;
+use log::info;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 use std::fs::File;
@@ -294,13 +293,13 @@ where
     HttpClient: crate::http::Client<Request = reqwest::Request, Response = reqwest::Response>,
 {
     let network_info = ctx.arweave().get_network_info(ctx).await.map_err(|err| {
-        paris::error!("Request for network info failed: {:?}", err);
+        error!("Request for network info failed: {:?}", err);
         CronJobError::ArweaveError(ArweaveError::UnknownErr)
     })?;
 
     let state = ctx.get_validator_state();
 
-    paris::info!("Update state: current_block={}", network_info.height);
+    info!("Update state: current_block={}", network_info.height);
     state.set_current_block(network_info.height);
 
     Ok(())

--- a/src/cron/bundle.rs
+++ b/src/cron/bundle.rs
@@ -17,7 +17,7 @@ use bundlr_sdk::deep_hash_sync::{deep_hash_sync, ONE_AS_BUFFER};
 use bundlr_sdk::verify::types::Item;
 use bundlr_sdk::{deep_hash::DeepHashChunk, verify::file::verify_file_bundle};
 use data_encoding::BASE64URL_NOPAD;
-use paris::{error, info};
+use log::{error, info};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Debug)]

--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use derive_more::{Display, Error};
 use futures::{join, Future};
-use paris::{error, info};
+use log::{error, info};
 use std::time::Duration;
 
 use self::{arweave::ArweaveError, error::ValidatorCronError};

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -130,7 +130,7 @@ impl KeyManager for InMemoryKeyManager {
 
     // TODO: should this return Result?
     // When returning Result, caller can decide what needs to be done if
-    // this call fails, instea of panicking internally.
+    // this call fails, instead of panicking here.
     fn validator_sign(&self, data: &[u8]) -> Vec<u8> {
         let mut signer =
             sign::Signer::new(MessageDigest::sha256(), &self.validator_private).unwrap();

--- a/src/server/error/mod.rs
+++ b/src/server/error/mod.rs
@@ -6,7 +6,6 @@ use actix_web::{
 };
 use derive_more::{Display, Error};
 use openssl::error::ErrorStack;
-use paris::log;
 
 #[warn(dead_code)]
 #[derive(Debug, Display, Error)]
@@ -39,21 +38,21 @@ impl error::ResponseError for ValidatorServerError {
 
 impl From<ErrorStack> for ValidatorServerError {
     fn from(e: ErrorStack) -> Self {
-        log!("Error occurred while performing crypto function - {}", e);
+        log::error!("Error occurred while performing crypto function - {}", e);
         ValidatorServerError::InternalError
     }
 }
 
 impl From<JoinError> for ValidatorServerError {
     fn from(e: JoinError) -> Self {
-        log!("Error occurred while performing blocking task - {}", e);
+        log::error!("Error occurred while performing blocking task - {}", e);
         ValidatorServerError::InternalError
     }
 }
 
 impl From<diesel::result::Error> for ValidatorServerError {
     fn from(e: diesel::result::Error) -> Self {
-        log!("Error occurred while db op - {}", e);
+        log::error!("Error occurred while db op - {}", e);
         ValidatorServerError::InternalError
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,7 +12,7 @@ use diesel::{
     r2d2::{ConnectionManager, PooledConnection},
     PgConnection,
 };
-use paris::info;
+use log::info;
 use routes::get_tx::get_tx;
 use routes::index::index;
 

--- a/src/server/routes/sign.rs
+++ b/src/server/routes/sign.rs
@@ -6,7 +6,7 @@ use bundlr_sdk::deep_hash::{deep_hash, DeepHashChunk, ONE_AS_BUFFER};
 
 use data_encoding::BASE64URL_NOPAD;
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
-use paris::error;
+use log::error;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{


### PR DESCRIPTION
Move from `paris` to `log + env_logger`. Paris could be probably configured to match our needs, but using `log + env_logger` by default logs in a format that can be more easily parsed by different log parsers/analyzers and additionally, logging from `actix-web` parts are matching rest of the logging. Additionally, we wanted to add the module where the log message is written and by default, `paris` does not include it.

This PR also removes some uses of `unwrap` either by returning `Result::Err` from the function or using `expect` for better error messages. Additionally database queries do not `panic` internally anymore and pass `Result::Err` to the caller.