### PR TITLE
Feature/read wallet from stdin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "validator"
 version = "0.1.0"
 edition = "2021"
 default-run = "validator"
+rust-version = "1.62"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -7,7 +7,6 @@ use diesel::{
 use env_logger::Env;
 use jsonwebkey::{JsonWebKey, Key, PublicExponent, RsaPublic};
 use log::info;
-use serde::Deserialize;
 use std::{fs, net::SocketAddr, str::FromStr};
 use sysinfo::{System, SystemExt};
 use url::Url;


### PR DESCRIPTION
Add support in wallet tool to read wallet data from `stdin` when used to extract wallet address.