### PR TITLE
Create 4096 bit keys when using wallet-tool

### DIFF
--- a/src/bin/wallet_tool.rs
+++ b/src/bin/wallet_tool.rs
@@ -29,7 +29,7 @@ fn main() {
 
     match args.command {
         Command::Create => {
-            let rsa = Rsa::generate(2048)
+            let rsa = Rsa::generate(4096)
                 .expect("Failed to generate enough random data for the private key");
 
             let jwk = JsonWebKey::new(Key::RSA {


### PR DESCRIPTION
Create 4096 bit private keys when generating new wallets with `wallet-tool`. With this change, keys generated with this tool are matching key size used by Arweave's tools.