### PR TITLE
:broom: Improve how request URL are build 

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -10,10 +10,16 @@ pub struct BundlerConfig {
     pub addresses: HashMap<String, String>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Bundler {
     pub address: String,
-    pub url: String, // FIXME: type of this field should be Url
+    pub url: Url,
+}
+
+impl Bundler {
+    pub fn new(address: String, url: Url) -> Self {
+        Bundler { address, url }
+    }
 }
 
 impl BundlerConfig {

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,7 +67,7 @@ impl AppContext {
     ) -> Self {
         let bundler_connection = Bundler {
             address: key_manager.bundler_address().to_owned(),
-            url: bundler_url.to_string(),
+            url: bundler_url.clone(),
         };
 
         let arweave_client = Arweave {
@@ -226,7 +226,7 @@ pub mod test_utils {
 
         let bundler_connection = Bundler {
             address: key_manager.bundler_address().to_owned(),
-            url: "".to_string(),
+            url: Url::from_str("http://bundler.example.com").unwrap(),
         };
 
         let arweave_client = Arweave {
@@ -263,7 +263,7 @@ pub mod test_utils {
 
         let bundler_connection = Bundler {
             address: key_manager.bundler_address().to_owned(),
-            url: "".to_string(),
+            url: Url::from_str("http://bundler.example.com").unwrap(),
         };
 
         let arweave_client = Arweave {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
-use futures::Future;
 
 #[cfg(feature = "reqwest-client")]
 pub mod reqwest;
@@ -10,8 +9,6 @@ pub mod reqwest;
 pub use http::Method;
 
 pub use http::{method, request, response};
-
-use crate::retry;
 
 pub trait ClientAccess<HttpClient>
 where
@@ -57,8 +54,7 @@ pub mod mock {
         sync::{Arc, Mutex},
     };
 
-    use futures::{future::BoxFuture, Future};
-    use log::error;
+    use futures::future::BoxFuture;
 
     use super::Client;
 
@@ -212,7 +208,7 @@ pub mod mock {
                     Box::pin(std::future::ready(Ok(res)))
                 }
                 None => {
-                    error!("no handler found for {:?}", req);
+                    eprintln!("no handler found for {:?}", req);
                     Box::pin(std::future::ready(Err(MockHttpClientError::ResponseNotSet)))
                 }
             }


### PR DESCRIPTION
Use `Url` as the type instead of `String` where value represents
an URL.

Build all request URLs using `Url` type and append parts using `join`.
Also add urlencoding if missing when appending more complex parts in
the URL.