### PR TITLE
Fixed /bundles mount error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         target: /wallet.json
         read_only: true
       
-      - /bundles:/bundles
+      - bundles:/bundles
     environment:
      - VALIDATOR_KEY=./wallet.json
      - DATABASE_URL=${DATABASE_URL:-postgres://bundlr:bundlr@postgres:5432/bundlr}
@@ -62,3 +62,4 @@ services:
   
 volumes:
   postgres:
+  bundles:


### PR DESCRIPTION
When trying to launch docker-compose, it may throw a mount error:
`"error while creating mount source path: '/bundles': mkdir /bundles: read-only file system"`

Error screenshot: [Image](https://pasteboard.co/xOYZSj8T9q5N.png)

This solution slightly edits the volumes of "validator" service + adds the volume to "volumes" section at the end of the docker-compose.yml.